### PR TITLE
Add missing second (s) unit to units table

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -107,6 +107,7 @@ The extensions are designed to be intuitive (i.e. as commonly used by <a href="h
     {{ template "partials/symbol-table-start.html" . }}
 <tr><td>b</td><td><a href="http://en.wikipedia.org/wiki/Bit#Unit_and_symbol">bit</a></td></tr>
 <tr><td>B</td><td><a href="http://en.wikipedia.org/wiki/Bit#Unit_and_symbol">byte</a></td></tr>
+<tr><td>s</td><td>second (strftime)</td></tr>
 <tr><td>M</td><td>minute (strftime)</td></tr>
 <tr><td>h</td><td>hour (strftime)</td></tr>
 <tr><td>d</td><td>day (strftime) </td></tr>


### PR DESCRIPTION
There is an implied missing metric unit of _seconds_ when defining the `rate` metric/target type:

```blockquote
rate: a number per second (implies that unit ends on '/s')
```

There are also other references to second too. This pull request simple adds the missing unit to the units table in the spec file.